### PR TITLE
feat: implement memorymap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,6 +614,7 @@ dependencies = [
  "leptos_actix",
  "leptos_meta",
  "leptos_router",
+ "memmap2",
  "serde",
  "tokio",
  "wasm-bindgen",
@@ -1545,6 +1546,15 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "memmap2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ leptos_meta = { version = "0.8.2" }
 leptos_actix = { version = "0.8.2", optional = true }
 leptos_router = { version = "0.8.2", features = ["nightly"] }
 wasm-bindgen = "=0.2.100"
+memmap2 = { version = "0.9.5", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.45.1", features = ["macros", "rt"] }
@@ -31,6 +32,8 @@ ssr = [
   "leptos/ssr",
   "leptos_meta/ssr",
   "leptos_router/ssr",
+
+  "dep:memmap2",
 ]
 
 # Defines a size-optimized profile for the WASM bundle in release mode

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,19 +11,21 @@ async fn main() -> std::io::Result<()> {
     use delphinus::app::*;
     use leptos::config::get_configuration;
     use leptos::prelude::*;
-    use leptos_actix::{generate_route_list, LeptosRoutes};
+    use leptos_actix::{LeptosRoutes, generate_route_list};
     use leptos_meta::MetaTags;
 
     let conf = get_configuration(None).unwrap();
     let addr = conf.leptos_options.site_addr;
 
-    let jap_dictionary = utils::load_jap_dictionary(String::from("dictionaries/jp/new_jmdict.txt"))
-        .await
-        .expect("Failed to load Japanese Dictionary");
+    let jap_dictionary =
+        utils::JapaneseDictionary::init(String::from("dictionaries/jp/new_jmdict.txt"))
+            .await
+            .expect("Failed to load Japanese Dictionary");
 
-    let ch_dictionary = utils::load_ch_dictionary(String::from("dictionaries/ch/cedict_ts.u8"))
-        .await
-        .expect("Failed to load Japanese Dictionary");
+    let ch_dictionary =
+        utils::ChineseDictionary::init(String::from("dictionaries/ch/cedict_ts.u8"))
+            .await
+            .expect("Failed to load Chinese Dictionary");
 
     println!("listening on http://{}", &addr);
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -87,7 +87,7 @@ impl ChineseDictionary {
         }
 
         line_offsets.shrink_to_fit();
-        log!("Indexed {} lines in dictionary", line_offsets.len());
+        log!("Indexed {} lines in chinese dictionary", line_offsets.len());
 
         Ok(ChineseDictionary { mmap, line_offsets })
     }
@@ -199,7 +199,10 @@ impl JapaneseDictionary {
         }
 
         line_offsets.shrink_to_fit();
-        log!("Indexed {} lines in dictionary", line_offsets.len());
+        log!(
+            "Indexed {} lines in japanese dictionary",
+            line_offsets.len()
+        );
 
         Ok(JapaneseDictionary { mmap, line_offsets })
     }
@@ -450,196 +453,5 @@ mod parse_tests {
         assert_eq!(remove_whitespace(" a b c "), "abc");
         assert_eq!(remove_whitespace("漢 字"), "漢字");
         assert_eq!(remove_whitespace(""), "");
-    }
-}
-
-#[cfg(test)]
-mod dict_tests {
-    use super::*;
-    use std::io::BufRead;
-
-    async fn search_dictionary_internal(
-        chars_string: String,
-        is_ch: bool,
-        dict_entries: &[DictionaryEntry],
-    ) -> Vec<Flashcard> {
-        use std::collections::{HashMap, HashSet};
-
-        let chars_array = if is_ch {
-            parse_ch_input(&chars_string)
-        } else {
-            parse_jap_input(&chars_string)
-        };
-
-        if chars_array.is_empty() {
-            return Vec::new();
-        }
-
-        let mut flashcards = Vec::with_capacity(chars_array.len() * 2);
-        let mut seen_chars = HashSet::with_capacity(chars_array.len());
-        let mut id_counter = 1;
-
-        let search_chars: HashSet<&str> = chars_array.iter().map(|s| s.trim()).collect();
-
-        let mut char_to_entries: HashMap<&str, Vec<&DictionaryEntry>> =
-            HashMap::with_capacity(search_chars.len());
-
-        for entry in dict_entries {
-            let hanzi = entry.hanzi.trim();
-            if search_chars.contains(hanzi) {
-                char_to_entries.entry(hanzi).or_default().push(entry);
-            }
-        }
-
-        for &ch in &chars_array {
-            let trimmed_ch = ch.trim();
-            if seen_chars.insert(trimmed_ch) {
-                if let Some(entries) = char_to_entries.get(trimmed_ch) {
-                    for entry in entries {
-                        flashcards.push(Flashcard {
-                            id: id_counter,
-                            front: RwSignal::new(entry.hanzi.clone()),
-                            back: RwSignal::new(format!("{} {}", entry.lecture, entry.definition)),
-                        });
-                        id_counter += 1;
-                    }
-                } else {
-                    flashcards.push(Flashcard {
-                        id: id_counter,
-                        front: RwSignal::new(trimmed_ch.to_string()),
-                        back: RwSignal::new("NOT FOUND".to_string()),
-                    });
-                    id_counter += 1;
-                }
-            }
-        }
-
-        flashcards
-    }
-
-    #[tokio::test]
-    async fn test_search_dictionary_internal() {
-        let dict = vec![
-            DictionaryEntry {
-                id: 1,
-                hanzi: "你".to_string(),
-                lecture: "ni3".to_string(),
-                definition: "you".to_string(),
-            },
-            DictionaryEntry {
-                id: 2,
-                hanzi: "好".to_string(),
-                lecture: "hao3".to_string(),
-                definition: "good".to_string(),
-            },
-        ];
-
-        let result = search_dictionary_internal("你,好,他".to_string(), true, &dict).await;
-
-        assert_eq!(result.len(), 3);
-        assert_eq!(result[0].front.get_untracked(), "你");
-        assert_eq!(result[1].front.get_untracked(), "好");
-        assert_eq!(result[1].back.get_untracked(), "hao3 good");
-        assert_eq!(result[2].front.get_untracked(), "他");
-        assert_eq!(result[2].back.get_untracked(), "NOT FOUND");
-    }
-
-    #[test]
-    fn test_load_jap_dictionary_parsing() {
-        let data = "\
-                    お嫁さん [およめさん] wife
-                    お菓子 [おかし] confections | sweets | candy | cake
-                    お願いします [おねがいします] please
-                    お願いいたします [おねがいいたします] please
-                ";
-
-        let cursor = std::io::Cursor::new(data);
-
-        let reader = std::io::BufReader::new(cursor);
-        let mut entries = Vec::new();
-
-        for (id, line) in reader.lines().enumerate() {
-            let line = line.unwrap();
-            let trimmed_line = line.trim();
-            if trimmed_line.is_empty() {
-                continue;
-            }
-
-            if let Some(start_bracket) = trimmed_line.find('[') {
-                if let Some(end_bracket) = trimmed_line.find(']') {
-                    let hanzi_part = &trimmed_line[..start_bracket].trim();
-                    let lecture = &trimmed_line[start_bracket + 1..end_bracket];
-                    let definitions = &trimmed_line[end_bracket + 1..];
-
-                    let hanzi = hanzi_part.split_whitespace().last().unwrap_or("").trim();
-
-                    if !hanzi.is_empty() {
-                        entries.push(DictionaryEntry {
-                            id: id + 1,
-                            hanzi: hanzi.to_string(),
-                            lecture: lecture.to_string(),
-                            definition: definitions.trim().to_string(),
-                        });
-                    }
-                }
-            }
-        }
-
-        assert_eq!(entries.len(), 4);
-        assert_eq!(entries[0].hanzi, "お嫁さん");
-        assert_eq!(entries[1].definition, "confections | sweets | candy | cake");
-    }
-
-    #[test]
-    fn test_load_ch_dictionary_parsing() {
-        let data = "\
-                    偩 偩 [fu4] /to rely on/to resemble/
-                    偪 逼 [bi1] /variant of 逼[bi1]/to compel/to pressure/
-                    偫 偫 [zhi4] /to wait for/to lay in/
-                    偭 偭 [mian3] /to transgress/
-                    偯 偯 [yi3] /to sob/wail/
-                    偰 偰 [xie4] /contract (variant of 契[qi4])/
-                    偱 偱 [xun2] /to tell/
-                    偲 偲 [si1] /talented/urgent/
-                ";
-
-        let cursor = std::io::Cursor::new(data);
-
-        let reader = std::io::BufReader::new(cursor);
-        let mut entries = Vec::new();
-
-        for (id, line) in reader.lines().enumerate() {
-            let line = line.unwrap();
-            let trimmed_line = line.trim();
-            if trimmed_line.is_empty() {
-                continue;
-            }
-
-            if let Some(start_bracket) = trimmed_line.find('[') {
-                if let Some(end_bracket) = trimmed_line.find(']') {
-                    let hanzi_part = &trimmed_line[..start_bracket].trim();
-                    let lecture = &trimmed_line[start_bracket + 1..end_bracket];
-                    let definitions = &trimmed_line[end_bracket + 1..];
-
-                    let hanzi = hanzi_part.split_whitespace().last().unwrap_or("").trim();
-
-                    if !hanzi.is_empty() {
-                        entries.push(DictionaryEntry {
-                            id: id + 1,
-                            hanzi: hanzi.to_string(),
-                            lecture: lecture.to_string(),
-                            definition: definitions.trim().to_string(),
-                        });
-                    }
-                }
-            }
-        }
-
-        assert_eq!(entries.len(), 8);
-        assert_eq!(entries[0].hanzi, "偩");
-        assert_eq!(
-            entries[1].definition,
-            "/variant of 逼[bi1]/to compel/to pressure/"
-        );
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,12 +2,13 @@ use leptos::prelude::*;
 use leptos::server;
 use serde::{Deserialize, Serialize};
 
+mod chinese_dict;
+mod japanese_dict;
+
 #[cfg(feature = "ssr")]
-use memmap2::Mmap;
+pub use chinese_dict::ChineseDictionary;
 #[cfg(feature = "ssr")]
-use std::collections::HashMap;
-#[cfg(feature = "ssr")]
-use std::sync::Arc;
+pub use japanese_dict::JapaneseDictionary;
 
 pub fn parse_ch_input(input: &str) -> Vec<&str> {
     match input {
@@ -39,252 +40,11 @@ pub struct DictionaryEntry {
     pub definition: String,
 }
 
-#[cfg(feature = "ssr")]
-#[derive(Clone)]
-pub struct JapaneseDictionary {
-    mmap: Arc<Mmap>,
-    line_offsets: Vec<(usize, usize)>, // (start, end) positions for each line
-}
-
-#[cfg(feature = "ssr")]
-#[derive(Clone)]
-pub struct ChineseDictionary {
-    mmap: Arc<Mmap>,
-    line_offsets: Vec<(usize, usize)>,
-}
-
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Hash)]
 pub struct Flashcard {
     pub id: i32,
     pub front: RwSignal<String>,
     pub back: RwSignal<String>,
-}
-
-#[cfg(feature = "ssr")]
-impl ChineseDictionary {
-    /// Init the chinese dictionary
-    pub async fn init(dictionary_path: String) -> Result<ChineseDictionary, ServerFnError> {
-        use leptos::logging::log;
-
-        let file = std::fs::File::open(dictionary_path).expect("Failed to open file");
-        let mmap = unsafe { memmap2::Mmap::map(&file).expect("Failed to create memory map") };
-        let mmap = std::sync::Arc::new(mmap);
-
-        // Build index of line positions instead of parsing all entries
-        let mut line_offsets = Vec::with_capacity(140000);
-        let mut start = 0;
-
-        for (pos, &byte) in mmap.iter().enumerate() {
-            if byte == b'\n' {
-                line_offsets.push((start, pos));
-                start = pos + 1;
-            }
-        }
-
-        // Handle last line if file doesn't end with newline
-        if start < mmap.len() {
-            line_offsets.push((start, mmap.len()));
-        }
-
-        line_offsets.shrink_to_fit();
-        log!("Indexed {} lines in chinese dictionary", line_offsets.len());
-
-        Ok(ChineseDictionary { mmap, line_offsets })
-    }
-
-    /// Get all entries of the dictionary
-    pub fn entries(&self) -> impl Iterator<Item = DictionaryEntry> + '_ {
-        self.line_offsets
-            .iter()
-            .enumerate()
-            .filter_map(|(id, &(start, end))| {
-                let line_bytes = &self.mmap[start..end];
-                if let Ok(line) = std::str::from_utf8(line_bytes) {
-                    self.parse_line(line, id)
-                } else {
-                    None
-                }
-            })
-    }
-
-    /// Search without loading all entries
-    pub fn search(&self, query: &str) -> Vec<DictionaryEntry> {
-        self.entries()
-            .filter(|entry| entry.hanzi.contains(query) || entry.definition.contains(query))
-            .collect()
-    }
-
-    /// Find entries for specific characters
-    pub fn find_entries_for_chars(
-        &self,
-        search_chars: &std::collections::HashSet<&str>,
-    ) -> HashMap<String, Vec<DictionaryEntry>> {
-        let mut char_to_entries: HashMap<String, Vec<DictionaryEntry>> =
-            HashMap::with_capacity(search_chars.len());
-
-        for (id, &(start, end)) in self.line_offsets.iter().enumerate() {
-            let line_bytes = &self.mmap[start..end];
-            if let Ok(line) = std::str::from_utf8(line_bytes) {
-                let contains_search_char = search_chars.iter().any(|&ch| line.contains(ch));
-                if !contains_search_char {
-                    continue;
-                }
-
-                if let Some(entry) = self.parse_line(line, id) {
-                    let hanzi = entry.hanzi.trim();
-                    if search_chars.contains(hanzi) {
-                        char_to_entries
-                            .entry(hanzi.to_string())
-                            .or_default()
-                            .push(entry);
-                    }
-                }
-            }
-        }
-
-        char_to_entries
-    }
-
-    fn parse_line(&self, line: &str, id: usize) -> Option<DictionaryEntry> {
-        let trimmed_line = line.trim();
-        if trimmed_line.is_empty() {
-            return None;
-        }
-
-        if let Some(start_bracket) = trimmed_line.find('[') {
-            if let Some(end_bracket) = trimmed_line.find(']') {
-                let hanzi_part = &trimmed_line[..start_bracket].trim();
-                let lecture = &trimmed_line[start_bracket + 1..end_bracket];
-                let definitions = &trimmed_line[end_bracket + 1..];
-                let hanzi = hanzi_part.split_whitespace().last().unwrap_or("").trim();
-
-                if !hanzi.is_empty() {
-                    return Some(DictionaryEntry {
-                        id: id + 1,
-                        hanzi: hanzi.to_string(),
-                        lecture: lecture.to_string(),
-                        definition: definitions.trim().to_string(),
-                    });
-                }
-            }
-        }
-        None
-    }
-}
-
-#[cfg(feature = "ssr")]
-impl JapaneseDictionary {
-    /// Init the chinese dictionary
-    pub async fn init(dictionary_path: String) -> Result<JapaneseDictionary, ServerFnError> {
-        use leptos::logging::log;
-
-        let file = std::fs::File::open(dictionary_path).expect("Failed to open file");
-        let mmap = unsafe { memmap2::Mmap::map(&file).expect("Failed to create memory map") };
-        let mmap = std::sync::Arc::new(mmap);
-
-        // Build index of line positions instead of parsing all entries
-        let mut line_offsets = Vec::with_capacity(140000);
-        let mut start = 0;
-
-        for (pos, &byte) in mmap.iter().enumerate() {
-            if byte == b'\n' {
-                line_offsets.push((start, pos));
-                start = pos + 1;
-            }
-        }
-
-        // Handle last line if file doesn't end with newline
-        if start < mmap.len() {
-            line_offsets.push((start, mmap.len()));
-        }
-
-        line_offsets.shrink_to_fit();
-        log!(
-            "Indexed {} lines in japanese dictionary",
-            line_offsets.len()
-        );
-
-        Ok(JapaneseDictionary { mmap, line_offsets })
-    }
-
-    /// Get all entries of the dictionary
-    pub fn entries(&self) -> impl Iterator<Item = DictionaryEntry> + '_ {
-        self.line_offsets
-            .iter()
-            .enumerate()
-            .filter_map(|(id, &(start, end))| {
-                let line_bytes = &self.mmap[start..end];
-                if let Ok(line) = std::str::from_utf8(line_bytes) {
-                    self.parse_line(line, id)
-                } else {
-                    None
-                }
-            })
-    }
-
-    /// Method to search without loading all entries
-    pub fn search(&self, query: &str) -> Vec<DictionaryEntry> {
-        self.entries()
-            .filter(|entry| entry.hanzi.contains(query) || entry.definition.contains(query))
-            .collect()
-    }
-
-    /// Find entries for specific characters
-    pub fn find_entries_for_chars(
-        &self,
-        search_chars: &std::collections::HashSet<&str>,
-    ) -> HashMap<String, Vec<DictionaryEntry>> {
-        let mut char_to_entries: HashMap<String, Vec<DictionaryEntry>> =
-            HashMap::with_capacity(search_chars.len());
-
-        for (id, &(start, end)) in self.line_offsets.iter().enumerate() {
-            let line_bytes = &self.mmap[start..end];
-            if let Ok(line) = std::str::from_utf8(line_bytes) {
-                let contains_search_char = search_chars.iter().any(|&ch| line.contains(ch));
-                if !contains_search_char {
-                    continue;
-                }
-
-                if let Some(entry) = self.parse_line(line, id) {
-                    let hanzi = entry.hanzi.trim();
-                    if search_chars.contains(hanzi) {
-                        char_to_entries
-                            .entry(hanzi.to_string())
-                            .or_default()
-                            .push(entry);
-                    }
-                }
-            }
-        }
-
-        char_to_entries
-    }
-
-    fn parse_line(&self, line: &str, id: usize) -> Option<DictionaryEntry> {
-        let trimmed_line = line.trim();
-        if trimmed_line.is_empty() {
-            return None;
-        }
-
-        if let Some(start_bracket) = trimmed_line.find('[') {
-            if let Some(end_bracket) = trimmed_line.find(']') {
-                let hanzi_part = &trimmed_line[..start_bracket].trim();
-                let lecture = &trimmed_line[start_bracket + 1..end_bracket];
-                let definitions = &trimmed_line[end_bracket + 1..];
-                let hanzi = hanzi_part.split_whitespace().last().unwrap_or("").trim();
-
-                if !hanzi.is_empty() {
-                    return Some(DictionaryEntry {
-                        id: id + 1,
-                        hanzi: hanzi.to_string(),
-                        lecture: lecture.to_string(),
-                        definition: definitions.trim().to_string(),
-                    });
-                }
-            }
-        }
-        None
-    }
 }
 
 #[server(SearchDictionary, "/searchdictionary")]
@@ -313,7 +73,7 @@ pub async fn search_dictionary(
     let search_chars: HashSet<&str> = chars_array.iter().map(|s| s.trim()).collect();
 
     if is_ch {
-        let ch_dictionary: Data<ChineseDictionary> = extract().await?;
+        let ch_dictionary: Data<chinese_dict::ChineseDictionary> = extract().await?;
         let char_to_entries = ch_dictionary.find_entries_for_chars(&search_chars);
 
         for &ch in &chars_array {
@@ -339,7 +99,7 @@ pub async fn search_dictionary(
             }
         }
     } else {
-        let jap_dictionary: Data<JapaneseDictionary> = extract().await?;
+        let jap_dictionary: Data<japanese_dict::JapaneseDictionary> = extract().await?;
         let char_to_entries = jap_dictionary.find_entries_for_chars(&search_chars);
 
         for &jp in &chars_array {

--- a/src/utils/chinese_dict.rs
+++ b/src/utils/chinese_dict.rs
@@ -1,0 +1,130 @@
+#[cfg(feature = "ssr")]
+use leptos::prelude::*;
+#[cfg(feature = "ssr")]
+use memmap2::Mmap;
+#[cfg(feature = "ssr")]
+use std::collections::HashMap;
+#[cfg(feature = "ssr")]
+use std::sync::Arc;
+
+#[cfg(feature = "ssr")]
+use crate::utils::DictionaryEntry;
+
+#[cfg(feature = "ssr")]
+#[derive(Clone)]
+pub struct ChineseDictionary {
+    mmap: Arc<Mmap>,
+    line_offsets: Vec<(usize, usize)>,
+}
+
+#[cfg(feature = "ssr")]
+impl ChineseDictionary {
+    /// Init the chinese dictionary
+    pub async fn init(dictionary_path: String) -> Result<ChineseDictionary, ServerFnError> {
+        use leptos::logging::log;
+
+        let file = std::fs::File::open(dictionary_path).expect("Failed to open file");
+        let mmap = unsafe { memmap2::Mmap::map(&file).expect("Failed to create memory map") };
+        let mmap = std::sync::Arc::new(mmap);
+
+        // Build index of line positions instead of parsing all entries
+        let mut line_offsets = Vec::with_capacity(140000);
+        let mut start = 0;
+
+        for (pos, &byte) in mmap.iter().enumerate() {
+            if byte == b'\n' {
+                line_offsets.push((start, pos));
+                start = pos + 1;
+            }
+        }
+
+        // Handle last line if file doesn't end with newline
+        if start < mmap.len() {
+            line_offsets.push((start, mmap.len()));
+        }
+
+        line_offsets.shrink_to_fit();
+        log!("Indexed {} lines in chinese dictionary", line_offsets.len());
+
+        Ok(ChineseDictionary { mmap, line_offsets })
+    }
+
+    /// Get all entries of the dictionary
+    pub fn entries(&self) -> impl Iterator<Item = DictionaryEntry> + '_ {
+        self.line_offsets
+            .iter()
+            .enumerate()
+            .filter_map(|(id, &(start, end))| {
+                let line_bytes = &self.mmap[start..end];
+                if let Ok(line) = std::str::from_utf8(line_bytes) {
+                    self.parse_line(line, id)
+                } else {
+                    None
+                }
+            })
+    }
+
+    /// Search without loading all entries
+    pub fn search(&self, query: &str) -> Vec<DictionaryEntry> {
+        self.entries()
+            .filter(|entry| entry.hanzi.contains(query) || entry.definition.contains(query))
+            .collect()
+    }
+
+    /// Find entries for specific characters
+    pub fn find_entries_for_chars(
+        &self,
+        search_chars: &std::collections::HashSet<&str>,
+    ) -> HashMap<String, Vec<DictionaryEntry>> {
+        let mut char_to_entries: HashMap<String, Vec<DictionaryEntry>> =
+            HashMap::with_capacity(search_chars.len());
+
+        for (id, &(start, end)) in self.line_offsets.iter().enumerate() {
+            let line_bytes = &self.mmap[start..end];
+            if let Ok(line) = std::str::from_utf8(line_bytes) {
+                let contains_search_char = search_chars.iter().any(|&ch| line.contains(ch));
+                if !contains_search_char {
+                    continue;
+                }
+
+                if let Some(entry) = self.parse_line(line, id) {
+                    let hanzi = entry.hanzi.trim();
+                    if search_chars.contains(hanzi) {
+                        char_to_entries
+                            .entry(hanzi.to_string())
+                            .or_default()
+                            .push(entry);
+                    }
+                }
+            }
+        }
+
+        char_to_entries
+    }
+
+    fn parse_line(&self, line: &str, id: usize) -> Option<DictionaryEntry> {
+        let trimmed_line = line.trim();
+        if trimmed_line.is_empty() {
+            return None;
+        }
+
+        if let Some(start_bracket) = trimmed_line.find('[') {
+            if let Some(end_bracket) = trimmed_line.find(']') {
+                let hanzi_part = &trimmed_line[..start_bracket].trim();
+                let lecture = &trimmed_line[start_bracket + 1..end_bracket];
+                let definitions = &trimmed_line[end_bracket + 1..];
+                let hanzi = hanzi_part.split_whitespace().last().unwrap_or("").trim();
+
+                if !hanzi.is_empty() {
+                    return Some(DictionaryEntry {
+                        id: id + 1,
+                        hanzi: hanzi.to_string(),
+                        lecture: lecture.to_string(),
+                        definition: definitions.trim().to_string(),
+                    });
+                }
+            }
+        }
+        None
+    }
+}

--- a/src/utils/japanese_dict.rs
+++ b/src/utils/japanese_dict.rs
@@ -1,0 +1,133 @@
+#[cfg(feature = "ssr")]
+use leptos::prelude::*;
+#[cfg(feature = "ssr")]
+use memmap2::Mmap;
+#[cfg(feature = "ssr")]
+use std::collections::HashMap;
+#[cfg(feature = "ssr")]
+use std::sync::Arc;
+
+#[cfg(feature = "ssr")]
+use crate::utils::DictionaryEntry;
+
+#[cfg(feature = "ssr")]
+#[derive(Clone)]
+pub struct JapaneseDictionary {
+    mmap: Arc<Mmap>,
+    line_offsets: Vec<(usize, usize)>, // (start, end) positions for each line
+}
+
+#[cfg(feature = "ssr")]
+impl JapaneseDictionary {
+    /// Init the chinese dictionary
+    pub async fn init(dictionary_path: String) -> Result<JapaneseDictionary, ServerFnError> {
+        use leptos::logging::log;
+
+        let file = std::fs::File::open(dictionary_path).expect("Failed to open file");
+        let mmap = unsafe { memmap2::Mmap::map(&file).expect("Failed to create memory map") };
+        let mmap = std::sync::Arc::new(mmap);
+
+        // Build index of line positions instead of parsing all entries
+        let mut line_offsets = Vec::with_capacity(140000);
+        let mut start = 0;
+
+        for (pos, &byte) in mmap.iter().enumerate() {
+            if byte == b'\n' {
+                line_offsets.push((start, pos));
+                start = pos + 1;
+            }
+        }
+
+        // Handle last line if file doesn't end with newline
+        if start < mmap.len() {
+            line_offsets.push((start, mmap.len()));
+        }
+
+        line_offsets.shrink_to_fit();
+        log!(
+            "Indexed {} lines in japanese dictionary",
+            line_offsets.len()
+        );
+
+        Ok(JapaneseDictionary { mmap, line_offsets })
+    }
+
+    /// Get all entries of the dictionary
+    pub fn entries(&self) -> impl Iterator<Item = DictionaryEntry> + '_ {
+        self.line_offsets
+            .iter()
+            .enumerate()
+            .filter_map(|(id, &(start, end))| {
+                let line_bytes = &self.mmap[start..end];
+                if let Ok(line) = std::str::from_utf8(line_bytes) {
+                    self.parse_line(line, id)
+                } else {
+                    None
+                }
+            })
+    }
+
+    /// Method to search without loading all entries
+    pub fn search(&self, query: &str) -> Vec<DictionaryEntry> {
+        self.entries()
+            .filter(|entry| entry.hanzi.contains(query) || entry.definition.contains(query))
+            .collect()
+    }
+
+    /// Find entries for specific characters
+    pub fn find_entries_for_chars(
+        &self,
+        search_chars: &std::collections::HashSet<&str>,
+    ) -> HashMap<String, Vec<DictionaryEntry>> {
+        let mut char_to_entries: HashMap<String, Vec<DictionaryEntry>> =
+            HashMap::with_capacity(search_chars.len());
+
+        for (id, &(start, end)) in self.line_offsets.iter().enumerate() {
+            let line_bytes = &self.mmap[start..end];
+            if let Ok(line) = std::str::from_utf8(line_bytes) {
+                let contains_search_char = search_chars.iter().any(|&ch| line.contains(ch));
+                if !contains_search_char {
+                    continue;
+                }
+
+                if let Some(entry) = self.parse_line(line, id) {
+                    let hanzi = entry.hanzi.trim();
+                    if search_chars.contains(hanzi) {
+                        char_to_entries
+                            .entry(hanzi.to_string())
+                            .or_default()
+                            .push(entry);
+                    }
+                }
+            }
+        }
+
+        char_to_entries
+    }
+
+    fn parse_line(&self, line: &str, id: usize) -> Option<DictionaryEntry> {
+        let trimmed_line = line.trim();
+        if trimmed_line.is_empty() {
+            return None;
+        }
+
+        if let Some(start_bracket) = trimmed_line.find('[') {
+            if let Some(end_bracket) = trimmed_line.find(']') {
+                let hanzi_part = &trimmed_line[..start_bracket].trim();
+                let lecture = &trimmed_line[start_bracket + 1..end_bracket];
+                let definitions = &trimmed_line[end_bracket + 1..];
+                let hanzi = hanzi_part.split_whitespace().last().unwrap_or("").trim();
+
+                if !hanzi.is_empty() {
+                    return Some(DictionaryEntry {
+                        id: id + 1,
+                        hanzi: hanzi.to_string(),
+                        lecture: lecture.to_string(),
+                        definition: definitions.trim().to_string(),
+                    });
+                }
+            }
+        }
+        None
+    }
+}


### PR DESCRIPTION
This PR introduces memory mapping for both the Chinese and Japanese dictionaries using the [memmap2](https://docs.rs/memmap2/latest/memmap2/) crate. As a result, the application's RAM usage drops significantly; from approximately 500 MB to just 40 MB.